### PR TITLE
Fixing .gitignore to better support eclipse development.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
 *.iml
 .idea
 target
+/.checkstyle
+/.classpath
+/.project
+/.settings


### PR DESCRIPTION
This provides a better developer experience when using eclipse for development.