### PR TITLE
#77 Fixed offset calculation for deleted records

### DIFF
--- a/src/main/java/com/epam/parso/impl/SasFileParser.java
+++ b/src/main/java/com/epam/parso/impl/SasFileParser.java
@@ -776,7 +776,7 @@ public final class SasFileParser {
         List<byte[]> vars = getBytesFromFile(new Long[] {deletedPointerOffset},
                 new Integer[] {PAGE_DELETED_POINTER_LENGTH});
 
-        long currentPageDeletedPointer = bytesToShort(vars.get(0));
+        long currentPageDeletedPointer = bytesToInt(vars.get(0));
         long deletedMapOffset = bitOffset + currentPageDeletedPointer + alignCorrection
                 + (currentPageSubheadersCount * subheaderPointerLength)
                 + ((currentPageBlockCount - currentPageSubheadersCount) * sasFileProperties.getRowLength());


### PR DESCRIPTION
Actually `vars.get(0)` is array of 4 bytes (its length is based on a SasFileConstants.PAGE_DELETED_POINTER_LENGTH = 4). So, it is more correct to use bytesToInt() conversion here instead of bytesToShort().